### PR TITLE
errors: make errors.Trace mid-stack inlineable

### DIFF
--- a/juju_adaptor.go
+++ b/juju_adaptor.go
@@ -9,6 +9,9 @@ import (
 
 // Trace just calls AddStack.
 func Trace(err error) error {
+	if err == nil {
+		return nil
+	}
 	return AddStack(err)
 }
 


### PR DESCRIPTION
go 1.12 with more aggressive inline strategy

https://tip.golang.org/doc/go1.12

> More functions are now eligible for inlining by default, including functions that do nothing but call another function. 

so `error.Trace` can be inlined in 1.12, let nil check to Trace make less low level method calling

```
goos: linux
goarch: amd64
pkg: github.com/pingcap/errors
BenchmarkOld-8   	100000000	        18.3 ns/op
BenchmarkNew-8   	1000000000	         2.26 ns/op
PASS
```

with default `-l`, go1.12 also can inline Trace,

```
go build -gcflags '-m=2 -N' 
# github.com/pingcap/errors/m/x
./m.go:14:6: can inline f2 as: func() error { return errors.New("") }
./m.go:15:19: inlining call to errors.New func(string) error { return error(&errors.fundamental literal) }
./m.go:15:19: inlining call to errors.callers func() *errors.stack { return errors.callersSkip(int(4)) }
./m.go:10:6: cannot inline f1: function too complex: cost 146 exceeds budget 80
./m.go:11:25: inlining call to f2 func() error { return errors.New("") }
./m.go:11:25: inlining call to errors.New func(string) error { return error(&errors.fundamental literal) }
./m.go:11:25: inlining call to errors.callers func() *errors.stack { return errors.callersSkip(int(4)) }
./m.go:11:22: inlining call to errors.Trace2 func(error) error { if errors.err == nil { return nil }; return errors.AddStack(errors.err) }

```

on another side in go1.11.3 

```
go build -gcflags '-m=2 -l=3 -N'  
# github.com/pingcap/errors/m/x
./m.go:14:6: cannot inline f2: function too complex: cost 84 exceeds budget 80
./m.go:10:6: cannot inline f1: function too complex: cost 165 exceeds budget 80
./m.go:5:6: cannot inline main: function too complex: cost 89 exceeds budget 80
```
and need -l=4 to make mid-stack inline, so this isn't work in version `< 1.12`

this modification is very similar to https://go-review.googlesource.com/c/go/+/156362/

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/errors/12)
<!-- Reviewable:end -->
