### PR TITLE
add NewNoStackError support

### DIFF
--- a/juju_adaptor.go
+++ b/juju_adaptor.go
@@ -55,6 +55,17 @@ func Annotatef(err error, format string, args ...interface{}) error {
 	}
 }
 
+var emptyStack stack
+
+// NewNoStackError creates error without error stack
+// later duplicate trace will no longer generate Stack too.
+func NewNoStackError(msg string) error {
+	return &fundamental{
+		msg:   msg,
+		stack: &emptyStack,
+	}
+}
+
 // ErrorStack will format a stack trace if it is available, otherwise it will be Error()
 // If the error is nil, the empty string is returned
 // Note that this just calls fmt.Sprintf("%+v", err)

--- a/stack_test.go
+++ b/stack_test.go
@@ -287,3 +287,13 @@ func TestNewStack(t *testing.T) {
 		t.Errorf("NewStack(): want: %v, got: %+v", "testing.tRunner", gotFirst)
 	}
 }
+
+func TestSuspendStackError(t *testing.T) {
+	err := NewNoStackError("test error")
+	err = Trace(err)
+	err = Trace(err)
+	result := fmt.Sprintf("%+v", err)
+	if result != "test error" {
+		t.Errorf("NewNoStackError(): want %s, got %v", "test error", result)
+	}
+}


### PR DESCRIPTION
## problem

some errors are frequent throws and used to control program logic.

for example:

- duplicate key error in database system
- conflict to retry error

they should not get heavy stack every time, and we can guess error throw place by err msg for those case.

get those stack and print them log is waste

## solution

add a `NewNoStackError` method, that error will use empty stack, later duplicate Trace call also NOT add stack for them.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/errors/13)
<!-- Reviewable:end -->
