### PR TITLE
add Unwrap to withMessage and withStack

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -181,6 +181,9 @@ type withStack struct {
 
 func (w *withStack) Cause() error { return w.error }
 
+// Unwrap provides compatibility for Go 1.13 error chains.
+func (w *withStack) Unwrap() error { return w.error }
+
 func (w *withStack) Format(s fmt.State, verb rune) {
 	switch verb {
 	case 'v':
@@ -263,6 +266,9 @@ type withMessage struct {
 func (w *withMessage) Error() string  { return w.msg + ": " + w.cause.Error() }
 func (w *withMessage) Cause() error   { return w.cause }
 func (w *withMessage) HasStack() bool { return w.causeHasStack }
+
+// Unwrap provides compatibility for Go 1.13 error chains.
+func (w *withMessage) Unwrap() error { return w.cause }
 
 func (w *withMessage) Format(s fmt.State, verb rune) {
 	switch verb {


### PR DESCRIPTION
1. We need to use `errors.Is` in Go 1.13, bug type `withMessage` and `withStack` not implemented  `Unwrap`.
2. In order to compatible with Go 1.13 error chains, add `Unwrap` to `withMessage` and `withStack`.