### PR TITLE
make Error compatible with functions in standard package

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -181,6 +181,9 @@ type withStack struct {
 
 func (w *withStack) Cause() error { return w.error }
 
+// Unwrap provides compatibility for Go 1.13 error chains.
+func (w *withStack) Unwrap() error { return w.error }
+
 func (w *withStack) Format(s fmt.State, verb rune) {
 	switch verb {
 	case 'v':
@@ -260,8 +263,11 @@ type withMessage struct {
 	causeHasStack bool
 }
 
-func (w *withMessage) Error() string  { return w.msg + ": " + w.cause.Error() }
-func (w *withMessage) Cause() error   { return w.cause }
+func (w *withMessage) Error() string { return w.msg + ": " + w.cause.Error() }
+func (w *withMessage) Cause() error  { return w.cause }
+
+// Unwrap provides compatibility for Go 1.13 error chains.
+func (w *withMessage) Unwrap() error  { return w.cause }
 func (w *withMessage) HasStack() bool { return w.causeHasStack }
 
 func (w *withMessage) Format(s fmt.State, verb rune) {

--- a/normalize.go
+++ b/normalize.go
@@ -255,6 +255,26 @@ func (e *Error) Wrap(err error) *Error {
 	return nil
 }
 
+// Unwrap returns cause of the error.
+// It allows Error to work with errors.Is() and errors.As() from the Go
+// standard package.
+func (e *Error) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.cause
+}
+
+// Is checks if e has the same error ID with other.
+// It allows Error to work with errors.Is() from the Go standard package.
+func (e *Error) Is(other error) bool {
+	err, ok := other.(*Error)
+	if !ok {
+		return false
+	}
+	return (e == nil && err == nil) || e.ID() == err.ID()
+}
+
 func (e *Error) Cause() error {
 	root := Unwrap(e.cause)
 	if root == nil {

--- a/normalize.go
+++ b/normalize.go
@@ -272,7 +272,7 @@ func (e *Error) Is(other error) bool {
 	if !ok {
 		return false
 	}
-	return (e == nil && err == nil) || e.ID() == err.ID()
+	return (e == nil && err == nil) || (e != nil && err != nil && e.ID() == err.ID())
 }
 
 func (e *Error) Cause() error {


### PR DESCRIPTION
Signed-off-by: disksing <i@disksing.com>

The current `Equals` is not friendly to multi-level wrap errors: it always unwraps the bottom-level error and then compares them.

For example, if the bottom level returns `os.NotExists`, we cannot wrap it with `kv.ErrNotExists.Wrap(err)`, because if we did that, we would not able to determine it later with `kv.ErrNotExists.Equals(err)` (the reason is `Equals` will recursively unwraps out `os.NotExists` then compare)

Now we deal this problem by throwing away the underlying error and just return `kv.ErrNotExists`, which is undoubtedly inappropriate because some information is lost and there is no way to tell if the error is `os.ErrorNotExists` anymore.

Go1.13 introduced the error wrapping mechanism in the standard package (https://golang.org/doc/go1.13#error_wrapping) and provides `errors.Is` / `errors.As` functions for error determination.

This PR adds two methods to make `Error` compatible with standard error wrapping.

- `Unwrap()` returns the next level of the error chain without recursion, so that Is/As can be checked for each level.
- `Is()` is used to ensure that all instances of `Error` with the same ID are judged to be equal.

There are 2 cases need to be noted:

1.
```go
e1 := fooError{}
e2 := Normalize("e2", RFCCodeText("e2"))
e21 := e2.Wrap(e1)
```
Since the ID of both `e2` and `e21` are "e2", so `errors.Is(e21, e2)` and `errors.Is(e2, e21)` are both `true`.

2.
```go
e1 := fooError{}
e2 := Normalize("e2", RFCCodeText("e2"))
e3 := Normalize("e3", RFCCodeText("e3"))
e21 := e2.Wrap(e1)

e3x := e3.Wrap(e1)
ok := errors.As(e21, &e3x)
```
In this case, although `e3x` and `e21` have different IDs, the are of the same type (both are `*Error`), so `As` returns `true` and `e3x.ID() == "e2"` afterward. Due to limitation of `errors.As`, this issue cannot be avoided by implementing an `As` function for `Error`.