### PR TITLE
normalize: expose the message arguments of the error

### DIFF
--- a/normalize.go
+++ b/normalize.go
@@ -106,6 +106,11 @@ func (e *Error) MessageTemplate() string {
 	return e.message
 }
 
+// Args returns the message arguments of this error.
+func (e *Error) Args() []interface{} {
+	return e.args
+}
+
 // Error implements error interface.
 func (e *Error) Error() string {
 	if e == nil {


### PR DESCRIPTION
This is useful because the error can be used as a string container, so the upper function can utilize it to refine the error messages.