### PR TITLE
fix: return new withStack directly so AddStack() is not added to the stack

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -172,10 +172,14 @@ func WithStack(err error) error {
 // AddStack is similar to WithStack.
 // However, it will first check with HasStack to see if a stack trace already exists in the causer chain before creating another one.
 func AddStack(err error) error {
-	if HasStack(err) {
+	if err == nil  || HasStack(err) {
 		return err
 	}
-	return WithStack(err)
+
+	return &withStack{
+		err,
+		callers(),
+	}
 }
 
 type withStack struct {


### PR DESCRIPTION
While I understand the desire to not re-implement `WithStack()`, by wrapping it in `AddStack()` the `AddStack()` function appears on the stack trace, unlike `WithStack()` which does not because `callers()` aliases `callersSkip(4)`.

Before:
```
example error
github.com/pingcap/errors.AddStack
	.../vendor/github.com/pingcap/errors/errors.go:174
main.bar
	.../main.go:18
main.foo
	.../main.go:14
main.main
	.../main.go:22
runtime.main
	/share/go/src/runtime/proc.go:267
runtime.goexit
	/share/go/src/runtime/asm_amd64.s:1650
```

After:
```
example error
main.bar
	.../main.go:18
main.foo
	.../main.go:14
main.main
	.../main.go:22
runtime.main
	/share/go/src/runtime/proc.go:267
runtime.goexit
	/share/go/src/runtime/asm_amd64.s:1650
```

Another solution would be to create a private function that both call, and up the `skipCallers` to 5, but they're such simple functions I dont think its necessary.