### PR TITLE
add GetSelfMsg to the error structs and GetErrStackMsg

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -91,6 +91,12 @@ import (
 	"io"
 )
 
+// represent an error carries with message
+type messenger interface {
+	// GetSelfMsg get its own message, the message of its cause error is NOT included.
+	GetSelfMsg() string
+}
+
 // New returns an error with the supplied message.
 // New also records the stack trace at the point it was called.
 func New(message string) error {
@@ -135,7 +141,11 @@ type fundamental struct {
 	*stack
 }
 
+var _ messenger = (*fundamental)(nil)
+
 func (f *fundamental) Error() string { return f.msg }
+
+func (f *fundamental) GetSelfMsg() string { return f.msg }
 
 func (f *fundamental) Format(s fmt.State, verb rune) {
 	switch verb {
@@ -172,7 +182,7 @@ func WithStack(err error) error {
 // AddStack is similar to WithStack.
 // However, it will first check with HasStack to see if a stack trace already exists in the causer chain before creating another one.
 func AddStack(err error) error {
-	if err == nil  || HasStack(err) {
+	if err == nil || HasStack(err) {
 		return err
 	}
 
@@ -187,7 +197,15 @@ type withStack struct {
 	*stack
 }
 
+var _ messenger = (*withStack)(nil)
+
 func (w *withStack) Cause() error { return w.error }
+
+func (w *withStack) GetSelfMsg() string {
+	// it doesn't have its own message, but we still need impl it to avoid calling
+	// err.Error() for its cause
+	return ""
+}
 
 // Unwrap provides compatibility for Go 1.13 error chains.
 func (w *withStack) Unwrap() error { return w.error }
@@ -271,8 +289,12 @@ type withMessage struct {
 	causeHasStack bool
 }
 
+var _ messenger = (*withMessage)(nil)
+
 func (w *withMessage) Error() string { return w.msg + ": " + w.cause.Error() }
 func (w *withMessage) Cause() error  { return w.cause }
+
+func (w *withMessage) GetSelfMsg() string { return w.msg }
 
 // Unwrap provides compatibility for Go 1.13 error chains.
 func (w *withMessage) Unwrap() error  { return w.cause }
@@ -337,4 +359,34 @@ func Find(origErr error, test func(error) bool) error {
 		return false
 	})
 	return foundErr
+}
+
+// GetErrStackMsg get the concat error message the whole error stack.
+// it's different from err.Error(), as pingcap/errors.Error will prepend the error
+// code in the result of err.Error(), like below:
+//
+//	[types:1292]Truncated incorrect
+//
+// and when there are multiple errors.Error in the chain, the err.Error() will
+// return like this:
+//
+//	[Lightning:Restore:ErrEncodeKV]encode kv error ... : [types:1292]Truncated incorrect DOUBLE value: 'a'"
+//
+// But sometimes we only want a single error code with pure message part.
+func GetErrStackMsg(err error) string {
+	if err == nil {
+		return ""
+	}
+	m, ok := err.(messenger)
+	if ok {
+		msg := m.GetSelfMsg()
+		causeMsg := GetErrStackMsg(Unwrap(err))
+		if msg == "" {
+			msg = causeMsg
+		} else if causeMsg != "" {
+			msg = msg + ": " + causeMsg
+		}
+		return msg
+	}
+	return err.Error()
 }

--- a/format_test.go
+++ b/format_test.go
@@ -27,7 +27,7 @@ func TestFormatNew(t *testing.T) {
 		"%+v",
 		"error\n" +
 			"github.com/pingcap/errors.TestFormatNew\n" +
-			"\t.+/github.com/pingcap/errors/format_test.go:26",
+			"\t.+/pingcap/errors/format_test.go:26",
 	}, {
 		New("error"),
 		"%q",
@@ -57,7 +57,7 @@ func TestFormatErrorf(t *testing.T) {
 		"%+v",
 		"error\n" +
 			"github.com/pingcap/errors.TestFormatErrorf\n" +
-			"\t.+/github.com/pingcap/errors/format_test.go:56",
+			"\t.+/pingcap/errors/format_test.go:56",
 	}}
 
 	for i, tt := range tests {
@@ -83,7 +83,7 @@ func TestFormatWrap(t *testing.T) {
 		"%+v",
 		"error\n" +
 			"github.com/pingcap/errors.TestFormatWrap\n" +
-			"\t.+/github.com/pingcap/errors/format_test.go:82",
+			"\t.+/pingcap/errors/format_test.go:82",
 	}, {
 		Annotate(io.EOF, "error"),
 		"%s",
@@ -98,14 +98,14 @@ func TestFormatWrap(t *testing.T) {
 		"EOF\n" +
 			"error\n" +
 			"github.com/pingcap/errors.TestFormatWrap\n" +
-			"\t.+/github.com/pingcap/errors/format_test.go:96",
+			"\t.+/pingcap/errors/format_test.go:96",
 	}, {
 		Annotate(Annotate(io.EOF, "error1"), "error2"),
 		"%+v",
 		"EOF\n" +
 			"error1\n" +
 			"github.com/pingcap/errors.TestFormatWrap\n" +
-			"\t.+/github.com/pingcap/errors/format_test.go:103\n",
+			"\t.+/pingcap/errors/format_test.go:103\n",
 	}, {
 		Annotate(New("error with space"), "context"),
 		"%q",
@@ -136,7 +136,7 @@ func TestFormatWrapf(t *testing.T) {
 		"EOF\n" +
 			"error2\n" +
 			"github.com/pingcap/errors.TestFormatWrapf\n" +
-			"\t.+/github.com/pingcap/errors/format_test.go:134",
+			"\t.+/pingcap/errors/format_test.go:134",
 	}, {
 		Annotatef(New("error"), "error%d", 2),
 		"%s",
@@ -150,7 +150,7 @@ func TestFormatWrapf(t *testing.T) {
 		"%+v",
 		"error\n" +
 			"github.com/pingcap/errors.TestFormatWrapf\n" +
-			"\t.+/github.com/pingcap/errors/format_test.go:149",
+			"\t.+/pingcap/errors/format_test.go:149",
 	}}
 
 	for i, tt := range tests {
@@ -176,7 +176,7 @@ func TestFormatWithStack(t *testing.T) {
 		"%+v",
 		[]string{"EOF",
 			"github.com/pingcap/errors.TestFormatWithStack\n" +
-				"\t.+/github.com/pingcap/errors/format_test.go:175"},
+				"\t.+/pingcap/errors/format_test.go:175"},
 	}, {
 		WithStack(New("error")),
 		"%s",
@@ -190,36 +190,36 @@ func TestFormatWithStack(t *testing.T) {
 		"%+v",
 		[]string{"error",
 			"github.com/pingcap/errors.TestFormatWithStack\n" +
-				"\t.+/github.com/pingcap/errors/format_test.go:189",
+				"\t.+/pingcap/errors/format_test.go:189",
 			"github.com/pingcap/errors.TestFormatWithStack\n" +
-				"\t.+/github.com/pingcap/errors/format_test.go:189"},
+				"\t.+/pingcap/errors/format_test.go:189"},
 	}, {
 		WithStack(WithStack(io.EOF)),
 		"%+v",
 		[]string{"EOF",
 			"github.com/pingcap/errors.TestFormatWithStack\n" +
-				"\t.+/github.com/pingcap/errors/format_test.go:197",
+				"\t.+/pingcap/errors/format_test.go:197",
 			"github.com/pingcap/errors.TestFormatWithStack\n" +
-				"\t.+/github.com/pingcap/errors/format_test.go:197"},
+				"\t.+/pingcap/errors/format_test.go:197"},
 	}, {
 		WithStack(WithStack(Annotatef(io.EOF, "message"))),
 		"%+v",
 		[]string{"EOF",
 			"message",
 			"github.com/pingcap/errors.TestFormatWithStack\n" +
-				"\t.+/github.com/pingcap/errors/format_test.go:205",
+				"\t.+/pingcap/errors/format_test.go:205",
 			"github.com/pingcap/errors.TestFormatWithStack\n" +
-				"\t.+/github.com/pingcap/errors/format_test.go:205",
+				"\t.+/pingcap/errors/format_test.go:205",
 			"github.com/pingcap/errors.TestFormatWithStack\n" +
-				"\t.+/github.com/pingcap/errors/format_test.go:205"},
+				"\t.+/pingcap/errors/format_test.go:205"},
 	}, {
 		WithStack(Errorf("error%d", 1)),
 		"%+v",
 		[]string{"error1",
 			"github.com/pingcap/errors.TestFormatWithStack\n" +
-				"\t.+/github.com/pingcap/errors/format_test.go:216",
+				"\t.+/pingcap/errors/format_test.go:216",
 			"github.com/pingcap/errors.TestFormatWithStack\n" +
-				"\t.+/github.com/pingcap/errors/format_test.go:216"},
+				"\t.+/pingcap/errors/format_test.go:216"},
 	}}
 
 	for i, tt := range tests {
@@ -246,7 +246,7 @@ func TestFormatWithMessage(t *testing.T) {
 		[]string{
 			"error",
 			"github.com/pingcap/errors.TestFormatWithMessage\n" +
-				"\t.+/github.com/pingcap/errors/format_test.go:244",
+				"\t.+/pingcap/errors/format_test.go:244",
 			"error2"},
 	}, {
 		WithMessage(io.EOF, "addition1"),
@@ -273,13 +273,13 @@ func TestFormatWithMessage(t *testing.T) {
 		"%+v",
 		[]string{"EOF", "error1", "error2",
 			"github.com/pingcap/errors.TestFormatWithMessage\n" +
-				"\t.+/github.com/pingcap/errors/format_test.go:272"},
+				"\t.+/pingcap/errors/format_test.go:272"},
 	}, {
 		WithMessage(Errorf("error%d", 1), "error2"),
 		"%+v",
 		[]string{"error1",
 			"github.com/pingcap/errors.TestFormatWithMessage\n" +
-				"\t.+/github.com/pingcap/errors/format_test.go:278",
+				"\t.+/pingcap/errors/format_test.go:278",
 			"error2"},
 	}, {
 		WithMessage(WithStack(io.EOF), "error"),
@@ -287,7 +287,7 @@ func TestFormatWithMessage(t *testing.T) {
 		[]string{
 			"EOF",
 			"github.com/pingcap/errors.TestFormatWithMessage\n" +
-				"\t.+/github.com/pingcap/errors/format_test.go:285",
+				"\t.+/pingcap/errors/format_test.go:285",
 			"error"},
 	}, {
 		WithMessage(Annotate(WithStack(io.EOF), "inside-error"), "outside-error"),
@@ -295,7 +295,7 @@ func TestFormatWithMessage(t *testing.T) {
 		[]string{
 			"EOF",
 			"github.com/pingcap/errors.TestFormatWithMessage\n" +
-				"\t.+/github.com/pingcap/errors/format_test.go:293",
+				"\t.+/pingcap/errors/format_test.go:293",
 			"inside-error",
 			"outside-error"},
 	}}
@@ -383,22 +383,21 @@ func testFormatRegexp(t *testing.T, n int, arg interface{}, format, want string)
 var stackLineR = regexp.MustCompile(`\.`)
 
 // parseBlocks parses input into a slice, where:
-//  - incase entry contains a newline, its a stacktrace
-//  - incase entry contains no newline, its a solo line.
+//   - incase entry contains a newline, its a stacktrace
+//   - incase entry contains no newline, its a solo line.
 //
 // Detecting stack boundaries only works incase the WithStack-calls are
 // to be found on the same line, thats why it is optionally here.
 //
 // Example use:
 //
-// for _, e := range blocks {
-//   if strings.ContainsAny(e, "\n") {
-//     // Match as stack
-//   } else {
-//     // Match as line
-//   }
-// }
-//
+//	for _, e := range blocks {
+//	  if strings.ContainsAny(e, "\n") {
+//	    // Match as stack
+//	  } else {
+//	    // Match as line
+//	  }
+//	}
 func parseBlocks(input string, detectStackboundaries bool) ([]string, error) {
 	var blocks []string
 

--- a/juju_adaptor.go
+++ b/juju_adaptor.go
@@ -76,6 +76,11 @@ func NewNoStackErrorf(format string, args ...interface{}) error {
 }
 
 // SuspendStack suspends stack generate for error.
+// Deprecated, it's semantic is to clear the stack inside, we still allow upper
+// layer to add stack again by using Trace.
+// Sometimes we have very deep calling stack, the lower layer calls SuspendStack,
+// but the upper layer want to add stack to it, if we disable adding stack permanently
+// for an error, it's very hard to diagnose certain issues.
 func SuspendStack(err error) error {
 	if err == nil {
 		return err

--- a/normalize.go
+++ b/normalize.go
@@ -82,6 +82,8 @@ type Error struct {
 	line  int
 }
 
+var _ messenger = (*Error)(nil)
+
 // Code returns the numeric code of this error.
 // ID() will return textual error if there it is,
 // when you just want to get the purely numeric error
@@ -127,10 +129,6 @@ func (e *Error) Error() string {
 	if e == nil {
 		return "<nil>"
 	}
-	describe := e.codeText
-	if len(describe) == 0 {
-		describe = ErrCodeText(strconv.Itoa(int(e.code)))
-	}
 	if e.cause != nil {
 		return fmt.Sprintf("[%s]%s: %s", e.RFCCode(), e.GetMsg(), e.cause.Error())
 	}
@@ -142,6 +140,10 @@ func (e *Error) GetMsg() string {
 		return fmt.Sprintf(e.message, e.args...)
 	}
 	return e.message
+}
+
+func (e *Error) GetSelfMsg() string {
+	return e.GetMsg()
 }
 
 func (e *Error) fillLineAndFile(skip int) {

--- a/terror_test/terror_test.go
+++ b/terror_test/terror_test.go
@@ -15,12 +15,13 @@ package terror_test
 
 import (
 	"encoding/json"
-	"github.com/stretchr/testify/suite"
 	"os"
 	"runtime"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/suite"
 
 	"github.com/pingcap/errors"
 )
@@ -76,7 +77,7 @@ func (s *TErrorTestSuite) TestTraceAndLocation() {
 			sysStack++
 		}
 	}
-	s.Equalf(13, len(lines)-(2*sysStack), "stack = \n%s", stack)
+	s.Equalf(11, len(lines)-(2*sysStack), "stack = \n%s", stack)
 	var containTerr bool
 	for _, v := range lines {
 		if strings.Contains(v, "terror_test.go") {


### PR DESCRIPTION
```go
// GetErrStackMsg get the concat error message the whole error stack.
// it's different from err.Error(), as pingcap/errors.Error will prepend the error
// code in the result of err.Error(), like below:
//
//	[types:1292]Truncated incorrect
//
// and when there are multiple errors.Error in the chain, the err.Error() will
// return like this:
//
//	[Lightning:Restore:ErrEncodeKV]encode kv error ... : [types:1292]Truncated incorrect DOUBLE value: 'a'"
//
// But sometimes we only want a single error code with pure message part.
```

And inside DXF, we need to store a pingcap/errors.Error struct into system table, also we want to keep all the annotated message within the struct, but we don't want the `[types:1292]` in the message, it's not clear to show to the user