### PR TITLE
normalize: freeze HackedStr args for lazy message rendering

### DIFF
--- a/bench_test.go
+++ b/bench_test.go
@@ -106,3 +106,44 @@ func BenchmarkStackFormatting(b *testing.B) {
 	}
 	GlobalE = stackStr
 }
+
+func BenchmarkByArgsArgFreeze(b *testing.B) {
+	errPrototype := Normalize("Incorrect time value: '%s'", RFCCodeText("Internal:Bench"))
+	stringArg := "120120519090607"
+
+	b.Run("FastGenByArgs-string", func(b *testing.B) {
+		var err error
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			err = errPrototype.FastGenByArgs(stringArg)
+		}
+		GlobalE = err
+	})
+
+	b.Run("FastGenByArgs-int", func(b *testing.B) {
+		var err error
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			err = errPrototype.FastGenByArgs(120120519090607)
+		}
+		GlobalE = err
+	})
+
+	b.Run("GenWithStackByArgs-string", func(b *testing.B) {
+		var err error
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			err = errPrototype.GenWithStackByArgs(stringArg)
+		}
+		GlobalE = err
+	})
+
+	b.Run("GenWithStackByArgs-int", func(b *testing.B) {
+		var err error
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			err = errPrototype.GenWithStackByArgs(120120519090607)
+		}
+		GlobalE = err
+	})
+}

--- a/bench_test.go
+++ b/bench_test.go
@@ -1,10 +1,10 @@
 package errors
 
 import (
-	"fmt"
-	"testing"
-
 	stderrors "errors"
+	"fmt"
+	"strings"
+	"testing"
 )
 
 func noErrors(at, depth int) error {
@@ -107,84 +107,172 @@ func BenchmarkStackFormatting(b *testing.B) {
 	GlobalE = stackStr
 }
 
+type argsProfile struct {
+	name           string
+	containsString bool
+	build          func(count, stringLen int) []interface{}
+}
+
+func buildStringArgs(count, stringLen int) []interface{} {
+	arg := strings.Repeat("x", stringLen)
+	args := make([]interface{}, count)
+	for i := range args {
+		args[i] = arg
+	}
+	return args
+}
+
+func buildIntArgs(count, _ int) []interface{} {
+	args := make([]interface{}, count)
+	for i := range args {
+		args[i] = i
+	}
+	return args
+}
+
+func buildMixedArgs(count, stringLen int) []interface{} {
+	strArg := strings.Repeat("x", stringLen)
+	args := make([]interface{}, count)
+	for i := range args {
+		switch i % 4 {
+		case 0:
+			args[i] = strArg
+		case 1:
+			args[i] = i
+		case 2:
+			args[i] = i%2 == 0
+		default:
+			args[i] = float64(i) + 0.25
+		}
+	}
+	return args
+}
+
+func benchmarkFormat(count int) string {
+	if count <= 0 {
+		return ""
+	}
+	format := "%v"
+	for i := 1; i < count; i++ {
+		format += " %v"
+	}
+	return format
+}
+
 func BenchmarkByArgsArgFreeze(b *testing.B) {
-	errPrototype := Normalize("Incorrect time value: '%s'", RFCCodeText("Internal:Bench"))
-	stringArg := "120120519090607"
+	errPrototype := Normalize("bench", RFCCodeText("Internal:Bench"))
 
-	b.Run("FastGenByArgs-string", func(b *testing.B) {
-		var err error
-		b.ReportAllocs()
-		for i := 0; i < b.N; i++ {
-			err = errPrototype.FastGenByArgs(stringArg)
-		}
-		GlobalE = err
-	})
+	apiCases := []struct {
+		name string
+		call func(errPrototype *Error, args []interface{}) error
+	}{
+		{
+			name: "FastGenByArgs",
+			call: func(errPrototype *Error, args []interface{}) error {
+				return errPrototype.FastGenByArgs(args...)
+			},
+		},
+	}
+	profiles := []argsProfile{
+		{name: "string", containsString: true, build: buildStringArgs},
+		{name: "int", containsString: false, build: buildIntArgs},
+	}
+	argCounts := []int{1, 4, 8}
+	stringLens := []int{16, 1024, 4096}
 
-	b.Run("FastGenByArgs-int", func(b *testing.B) {
-		var err error
-		b.ReportAllocs()
-		for i := 0; i < b.N; i++ {
-			err = errPrototype.FastGenByArgs(120120519090607)
-		}
-		GlobalE = err
-	})
+	for _, apiCase := range apiCases {
+		apiCase := apiCase
+		b.Run(apiCase.name, func(b *testing.B) {
+			for _, profile := range profiles {
+				profile := profile
+				lens := []int{0}
+				if profile.containsString {
+					lens = stringLens
+				}
+				for _, argCount := range argCounts {
+					argCount := argCount
+					for _, strLen := range lens {
+						strLen := strLen
+						args := profile.build(argCount, strLen)
+						caseName := fmt.Sprintf("type-%s/count-%d", profile.name, argCount)
+						if profile.containsString {
+							caseName = fmt.Sprintf("%s/strlen-%d", caseName, strLen)
+						}
 
-	b.Run("GenWithStackByArgs-string", func(b *testing.B) {
-		var err error
-		b.ReportAllocs()
-		for i := 0; i < b.N; i++ {
-			err = errPrototype.GenWithStackByArgs(stringArg)
-		}
-		GlobalE = err
-	})
-
-	b.Run("GenWithStackByArgs-int", func(b *testing.B) {
-		var err error
-		b.ReportAllocs()
-		for i := 0; i < b.N; i++ {
-			err = errPrototype.GenWithStackByArgs(120120519090607)
-		}
-		GlobalE = err
-	})
+						b.Run(caseName, func(b *testing.B) {
+							var err error
+							b.ReportAllocs()
+							for i := 0; i < b.N; i++ {
+								err = apiCase.call(errPrototype, args)
+							}
+							GlobalE = err
+						})
+					}
+				}
+			}
+		})
+	}
 }
 
 func BenchmarkFormatArgFreeze(b *testing.B) {
-	errPrototype := Normalize("Incorrect time value: '%s'", RFCCodeText("Internal:Bench"))
-	stringArg := "120120519090607"
+	errPrototype := Normalize("bench", RFCCodeText("Internal:Bench"))
 
-	b.Run("FastGen-string", func(b *testing.B) {
-		var err error
-		b.ReportAllocs()
-		for i := 0; i < b.N; i++ {
-			err = errPrototype.FastGen("Incorrect time value: '%s'", stringArg)
-		}
-		GlobalE = err
-	})
+	apiCases := []struct {
+		name string
+		call func(errPrototype *Error, format string, args []interface{}) error
+	}{
+		{
+			name: "FastGen",
+			call: func(errPrototype *Error, format string, args []interface{}) error {
+				return errPrototype.FastGen(format, args...)
+			},
+		},
+		{
+			name: "GenWithStack",
+			call: func(errPrototype *Error, format string, args []interface{}) error {
+				return errPrototype.GenWithStack(format, args...)
+			},
+		},
+	}
+	profiles := []argsProfile{
+		{name: "string", containsString: true, build: buildStringArgs},
+		{name: "int", containsString: false, build: buildIntArgs},
+		{name: "mixed", containsString: true, build: buildMixedArgs},
+	}
+	argCounts := []int{1, 4, 8}
+	stringLens := []int{16, 1024, 8192}
 
-	b.Run("FastGen-int", func(b *testing.B) {
-		var err error
-		b.ReportAllocs()
-		for i := 0; i < b.N; i++ {
-			err = errPrototype.FastGen("Incorrect time value: '%d'", 120120519090607)
-		}
-		GlobalE = err
-	})
+	for _, apiCase := range apiCases {
+		apiCase := apiCase
+		b.Run(apiCase.name, func(b *testing.B) {
+			for _, profile := range profiles {
+				profile := profile
+				lens := []int{0}
+				if profile.containsString {
+					lens = stringLens
+				}
+				for _, argCount := range argCounts {
+					argCount := argCount
+					format := benchmarkFormat(argCount)
+					for _, strLen := range lens {
+						strLen := strLen
+						args := profile.build(argCount, strLen)
+						caseName := fmt.Sprintf("type-%s/count-%d", profile.name, argCount)
+						if profile.containsString {
+							caseName = fmt.Sprintf("%s/strlen-%d", caseName, strLen)
+						}
 
-	b.Run("GenWithStack-string", func(b *testing.B) {
-		var err error
-		b.ReportAllocs()
-		for i := 0; i < b.N; i++ {
-			err = errPrototype.GenWithStack("Incorrect time value: '%s'", stringArg)
-		}
-		GlobalE = err
-	})
-
-	b.Run("GenWithStack-int", func(b *testing.B) {
-		var err error
-		b.ReportAllocs()
-		for i := 0; i < b.N; i++ {
-			err = errPrototype.GenWithStack("Incorrect time value: '%d'", 120120519090607)
-		}
-		GlobalE = err
-	})
+						b.Run(caseName, func(b *testing.B) {
+							var err error
+							b.ReportAllocs()
+							for i := 0; i < b.N; i++ {
+								err = apiCase.call(errPrototype, format, args)
+							}
+							GlobalE = err
+						})
+					}
+				}
+			}
+		})
+	}
 }

--- a/bench_test.go
+++ b/bench_test.go
@@ -163,8 +163,8 @@ func BenchmarkByArgsHackedStrFreeze(b *testing.B) {
 		{name: "plain", containsString: true, build: buildPlainStringArgs},
 		{name: "hacked", containsString: true, build: buildHackedStringArgs},
 	}
-	argCounts := []int{4}
-	stringLens := []int{16, 1024, 4096}
+	argCounts := []int{1, 4, 8}
+	stringLens := []int{16, 1024}
 
 	for _, apiCase := range apiCases {
 		apiCase := apiCase
@@ -179,7 +179,7 @@ func BenchmarkByArgsHackedStrFreeze(b *testing.B) {
 					argCount := argCount
 					for _, strLen := range lens {
 						strLen := strLen
-						args := profile.build(argCount, strLen)
+						templateArgs := profile.build(argCount, strLen)
 						caseName := fmt.Sprintf("type-%s/count-%d", profile.name, argCount)
 						if profile.containsString {
 							caseName = fmt.Sprintf("%s/strlen-%d", caseName, strLen)
@@ -187,8 +187,10 @@ func BenchmarkByArgsHackedStrFreeze(b *testing.B) {
 
 						b.Run(caseName, func(b *testing.B) {
 							var err error
+							args := make([]interface{}, len(templateArgs))
 							b.ReportAllocs()
 							for i := 0; i < b.N; i++ {
+								copy(args, templateArgs)
 								err = apiCase.call(errPrototype, args)
 							}
 							GlobalE = err

--- a/bench_test.go
+++ b/bench_test.go
@@ -113,7 +113,22 @@ type argsProfile struct {
 	build          func(count, stringLen int) []interface{}
 }
 
-func buildStringArgs(count, stringLen int) []interface{} {
+type benchmarkHackedStr string
+
+func (s benchmarkHackedStr) FreezeStr() string {
+	return string(append([]byte(nil), s...))
+}
+
+func buildHackedStringArgs(count, stringLen int) []interface{} {
+	arg := benchmarkHackedStr(strings.Repeat("x", stringLen))
+	args := make([]interface{}, count)
+	for i := range args {
+		args[i] = arg
+	}
+	return args
+}
+
+func buildPlainStringArgs(count, stringLen int) []interface{} {
 	arg := strings.Repeat("x", stringLen)
 	args := make([]interface{}, count)
 	for i := range args {
@@ -130,36 +145,7 @@ func buildIntArgs(count, _ int) []interface{} {
 	return args
 }
 
-func buildMixedArgs(count, stringLen int) []interface{} {
-	strArg := strings.Repeat("x", stringLen)
-	args := make([]interface{}, count)
-	for i := range args {
-		switch i % 4 {
-		case 0:
-			args[i] = strArg
-		case 1:
-			args[i] = i
-		case 2:
-			args[i] = i%2 == 0
-		default:
-			args[i] = float64(i) + 0.25
-		}
-	}
-	return args
-}
-
-func benchmarkFormat(count int) string {
-	if count <= 0 {
-		return ""
-	}
-	format := "%v"
-	for i := 1; i < count; i++ {
-		format += " %v"
-	}
-	return format
-}
-
-func BenchmarkByArgsArgFreeze(b *testing.B) {
+func BenchmarkByArgsHackedStrFreeze(b *testing.B) {
 	errPrototype := Normalize("bench", RFCCodeText("Internal:Bench"))
 
 	apiCases := []struct {
@@ -174,10 +160,10 @@ func BenchmarkByArgsArgFreeze(b *testing.B) {
 		},
 	}
 	profiles := []argsProfile{
-		{name: "string", containsString: true, build: buildStringArgs},
-		{name: "int", containsString: false, build: buildIntArgs},
+		{name: "plain", containsString: true, build: buildPlainStringArgs},
+		{name: "hacked", containsString: true, build: buildHackedStringArgs},
 	}
-	argCounts := []int{1, 4, 8}
+	argCounts := []int{4}
 	stringLens := []int{16, 1024, 4096}
 
 	for _, apiCase := range apiCases {
@@ -204,69 +190,6 @@ func BenchmarkByArgsArgFreeze(b *testing.B) {
 							b.ReportAllocs()
 							for i := 0; i < b.N; i++ {
 								err = apiCase.call(errPrototype, args)
-							}
-							GlobalE = err
-						})
-					}
-				}
-			}
-		})
-	}
-}
-
-func BenchmarkFormatArgFreeze(b *testing.B) {
-	errPrototype := Normalize("bench", RFCCodeText("Internal:Bench"))
-
-	apiCases := []struct {
-		name string
-		call func(errPrototype *Error, format string, args []interface{}) error
-	}{
-		{
-			name: "FastGen",
-			call: func(errPrototype *Error, format string, args []interface{}) error {
-				return errPrototype.FastGen(format, args...)
-			},
-		},
-		{
-			name: "GenWithStack",
-			call: func(errPrototype *Error, format string, args []interface{}) error {
-				return errPrototype.GenWithStack(format, args...)
-			},
-		},
-	}
-	profiles := []argsProfile{
-		{name: "string", containsString: true, build: buildStringArgs},
-		{name: "int", containsString: false, build: buildIntArgs},
-		{name: "mixed", containsString: true, build: buildMixedArgs},
-	}
-	argCounts := []int{1, 4, 8}
-	stringLens := []int{16, 1024, 8192}
-
-	for _, apiCase := range apiCases {
-		apiCase := apiCase
-		b.Run(apiCase.name, func(b *testing.B) {
-			for _, profile := range profiles {
-				profile := profile
-				lens := []int{0}
-				if profile.containsString {
-					lens = stringLens
-				}
-				for _, argCount := range argCounts {
-					argCount := argCount
-					format := benchmarkFormat(argCount)
-					for _, strLen := range lens {
-						strLen := strLen
-						args := profile.build(argCount, strLen)
-						caseName := fmt.Sprintf("type-%s/count-%d", profile.name, argCount)
-						if profile.containsString {
-							caseName = fmt.Sprintf("%s/strlen-%d", caseName, strLen)
-						}
-
-						b.Run(caseName, func(b *testing.B) {
-							var err error
-							b.ReportAllocs()
-							for i := 0; i < b.N; i++ {
-								err = apiCase.call(errPrototype, format, args)
 							}
 							GlobalE = err
 						})

--- a/bench_test.go
+++ b/bench_test.go
@@ -147,3 +147,44 @@ func BenchmarkByArgsArgFreeze(b *testing.B) {
 		GlobalE = err
 	})
 }
+
+func BenchmarkFormatArgFreeze(b *testing.B) {
+	errPrototype := Normalize("Incorrect time value: '%s'", RFCCodeText("Internal:Bench"))
+	stringArg := "120120519090607"
+
+	b.Run("FastGen-string", func(b *testing.B) {
+		var err error
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			err = errPrototype.FastGen("Incorrect time value: '%s'", stringArg)
+		}
+		GlobalE = err
+	})
+
+	b.Run("FastGen-int", func(b *testing.B) {
+		var err error
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			err = errPrototype.FastGen("Incorrect time value: '%d'", 120120519090607)
+		}
+		GlobalE = err
+	})
+
+	b.Run("GenWithStack-string", func(b *testing.B) {
+		var err error
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			err = errPrototype.GenWithStack("Incorrect time value: '%s'", stringArg)
+		}
+		GlobalE = err
+	})
+
+	b.Run("GenWithStack-int", func(b *testing.B) {
+		var err error
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			err = errPrototype.GenWithStack("Incorrect time value: '%d'", 120120519090607)
+		}
+		GlobalE = err
+	})
+}

--- a/normalize.go
+++ b/normalize.go
@@ -142,6 +142,20 @@ func (e *Error) GetMsg() string {
 	return e.message
 }
 
+func freezeStringArgs(args []interface{}) []interface{} {
+	frozenArgs := make([]interface{}, len(args))
+	copy(frozenArgs, args)
+	for i := range frozenArgs {
+		strArg, ok := frozenArgs[i].(string)
+		if !ok {
+			continue
+		}
+		// Freeze string args so delayed formatting can't observe later writes from zero-copy aliases.
+		frozenArgs[i] = string(append([]byte(nil), strArg...))
+	}
+	return frozenArgs
+}
+
 func (e *Error) GetSelfMsg() string {
 	return e.GetMsg()
 }
@@ -172,7 +186,7 @@ func (e *Error) GenWithStack(format string, args ...interface{}) error {
 func (e *Error) GenWithStackByArgs(args ...interface{}) error {
 	RedactErrorArg(args, e.redactArgsPos)
 	err := *e
-	err.args = args
+	err.args = freezeStringArgs(args)
 	err.fillLineAndFile(1)
 	return AddStack(&err)
 }
@@ -192,7 +206,7 @@ func (e *Error) FastGen(format string, args ...interface{}) error {
 func (e *Error) FastGenByArgs(args ...interface{}) error {
 	RedactErrorArg(args, e.redactArgsPos)
 	err := *e
-	err.args = args
+	err.args = freezeStringArgs(args)
 	return SuspendStack(&err)
 }
 

--- a/normalize.go
+++ b/normalize.go
@@ -42,6 +42,15 @@ type ErrCodeText string
 type ErrorID string
 type RFCErrorCode string
 
+// HackedStr can provide a stable string snapshot for unsafe/ephemeral string sources.
+// The method name intentionally uses FreezeStr instead of Clone so normal clone-style
+// types are not accidentally treated as error-format arguments.
+// During error construction, arguments implementing this interface are replaced
+// with FreezeStr() so deferred error formatting does not observe later mutations.
+type HackedStr interface {
+	FreezeStr() string
+}
+
 // Error is the 'prototype' of a type of errors.
 // Use DefineError to make a *Error:
 // var ErrUnavailable = errors.Normalize("Region %d is unavailable", errors.RFCCodeText("Unavailable"))
@@ -142,21 +151,20 @@ func (e *Error) GetMsg() string {
 	return e.message
 }
 
-func freezeStringArgs(args []interface{}) []interface{} {
+func freezeHackedStringArgs(args []interface{}) []interface{} {
 	// This helper intentionally mutates the input slice in place.
 	// It is only used inside error-construction paths where args are internal and should
 	// not be reused by callers after passing into Gen*/FastGen* APIs.
 	for i := range args {
-		strArg, ok := args[i].(string)
+		hackedArg, ok := args[i].(HackedStr)
 		if !ok {
 			continue
 		}
 		// TiDB may pass unsafe zero-copy strings (for example from chunk buffers) as error args.
 		// Error message rendering is deferred until GetMsg/Error, so without freezing here we may
 		// observe later writes and print a different value than the one used when creating the error.
-		// Copying at every call site in TiDB is more expensive; freezing in this central path keeps
-		// the copy cost only on error construction.
-		args[i] = string(append([]byte(nil), strArg...))
+		// Freezing in this central path keeps the copy cost only on error construction.
+		args[i] = hackedArg.FreezeStr()
 	}
 	return args
 }
@@ -182,7 +190,7 @@ func (e *Error) GenWithStack(format string, args ...interface{}) error {
 	// TODO: RedactErrorArg
 	err := *e
 	err.message = format
-	err.args = freezeStringArgs(args)
+	err.args = freezeHackedStringArgs(args)
 	err.fillLineAndFile(1)
 	return AddStack(&err)
 }
@@ -191,7 +199,7 @@ func (e *Error) GenWithStack(format string, args ...interface{}) error {
 func (e *Error) GenWithStackByArgs(args ...interface{}) error {
 	RedactErrorArg(args, e.redactArgsPos)
 	err := *e
-	err.args = freezeStringArgs(args)
+	err.args = freezeHackedStringArgs(args)
 	err.fillLineAndFile(1)
 	return AddStack(&err)
 }
@@ -202,7 +210,7 @@ func (e *Error) FastGen(format string, args ...interface{}) error {
 	// TODO: RedactErrorArg
 	err := *e
 	err.message = format
-	err.args = freezeStringArgs(args)
+	err.args = freezeHackedStringArgs(args)
 	return SuspendStack(&err)
 }
 
@@ -211,7 +219,7 @@ func (e *Error) FastGen(format string, args ...interface{}) error {
 func (e *Error) FastGenByArgs(args ...interface{}) error {
 	RedactErrorArg(args, e.redactArgsPos)
 	err := *e
-	err.args = freezeStringArgs(args)
+	err.args = freezeHackedStringArgs(args)
 	return SuspendStack(&err)
 }
 
@@ -332,7 +340,7 @@ func (e *Error) FastGenWithCause(args ...interface{}) error {
 	if e.cause != nil {
 		err.message = e.cause.Error()
 	}
-	err.args = freezeStringArgs(args)
+	err.args = freezeHackedStringArgs(args)
 	return SuspendStack(&err)
 }
 
@@ -341,7 +349,7 @@ func (e *Error) GenWithStackByCause(args ...interface{}) error {
 	if e.cause != nil {
 		err.message = e.cause.Error()
 	}
-	err.args = freezeStringArgs(args)
+	err.args = freezeHackedStringArgs(args)
 	err.fillLineAndFile(1)
 	return AddStack(&err)
 }

--- a/normalize.go
+++ b/normalize.go
@@ -150,7 +150,11 @@ func freezeStringArgs(args []interface{}) []interface{} {
 		if !ok {
 			continue
 		}
-		// Freeze string args so delayed formatting can't observe later writes from zero-copy aliases.
+		// TiDB may pass unsafe zero-copy strings (for example from chunk buffers) as error args.
+		// Error message rendering is deferred until GetMsg/Error, so without freezing here we may
+		// observe later writes and print a different value than the one used when creating the error.
+		// Copying at every call site in TiDB is more expensive; freezing in this central path keeps
+		// the copy cost only on error construction.
 		frozenArgs[i] = string(append([]byte(nil), strArg...))
 	}
 	return frozenArgs
@@ -177,7 +181,7 @@ func (e *Error) GenWithStack(format string, args ...interface{}) error {
 	// TODO: RedactErrorArg
 	err := *e
 	err.message = format
-	err.args = args
+	err.args = freezeStringArgs(args)
 	err.fillLineAndFile(1)
 	return AddStack(&err)
 }
@@ -197,7 +201,7 @@ func (e *Error) FastGen(format string, args ...interface{}) error {
 	// TODO: RedactErrorArg
 	err := *e
 	err.message = format
-	err.args = args
+	err.args = freezeStringArgs(args)
 	return SuspendStack(&err)
 }
 
@@ -327,7 +331,7 @@ func (e *Error) FastGenWithCause(args ...interface{}) error {
 	if e.cause != nil {
 		err.message = e.cause.Error()
 	}
-	err.args = args
+	err.args = freezeStringArgs(args)
 	return SuspendStack(&err)
 }
 
@@ -336,7 +340,7 @@ func (e *Error) GenWithStackByCause(args ...interface{}) error {
 	if e.cause != nil {
 		err.message = e.cause.Error()
 	}
-	err.args = args
+	err.args = freezeStringArgs(args)
 	err.fillLineAndFile(1)
 	return AddStack(&err)
 }

--- a/normalize.go
+++ b/normalize.go
@@ -143,10 +143,11 @@ func (e *Error) GetMsg() string {
 }
 
 func freezeStringArgs(args []interface{}) []interface{} {
-	frozenArgs := make([]interface{}, len(args))
-	copy(frozenArgs, args)
-	for i := range frozenArgs {
-		strArg, ok := frozenArgs[i].(string)
+	// This helper intentionally mutates the input slice in place.
+	// It is only used inside error-construction paths where args are internal and should
+	// not be reused by callers after passing into Gen*/FastGen* APIs.
+	for i := range args {
+		strArg, ok := args[i].(string)
 		if !ok {
 			continue
 		}
@@ -155,9 +156,9 @@ func freezeStringArgs(args []interface{}) []interface{} {
 		// observe later writes and print a different value than the one used when creating the error.
 		// Copying at every call site in TiDB is more expensive; freezing in this central path keeps
 		// the copy cost only on error construction.
-		frozenArgs[i] = string(append([]byte(nil), strArg...))
+		args[i] = string(append([]byte(nil), strArg...))
 	}
-	return frozenArgs
+	return args
 }
 
 func (e *Error) GetSelfMsg() string {

--- a/normalize_test.go
+++ b/normalize_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"regexp"
 	"testing"
+	"unsafe"
 )
 
 func errorMatches(t *testing.T, err error, re string) {
@@ -47,5 +48,35 @@ func TestRedactFormatter(t *testing.T) {
 	v = &redactFormatter{"‹"}
 	if a := fmt.Sprintf("%s", v); a != "‹‹‹›" {
 		t.Errorf("%s != <<<>", a)
+	}
+}
+
+func TestGenWithStackByArgsFreezeStringArg(t *testing.T) {
+	errTest := Normalize("Incorrect time value: '%s'", RFCCodeText("Internal:Test"))
+
+	origin := []byte("120120519090607")
+	arg := *(*string)(unsafe.Pointer(&origin))
+	err := errTest.GenWithStackByArgs(arg)
+
+	copy(origin, "1 1:1:1.0000027")
+	got := err.(*withStack).error.(*Error).GetMsg()
+	want := "Incorrect time value: '120120519090607'"
+	if got != want {
+		t.Fatalf("message changed after source bytes mutated, got %q, want %q", got, want)
+	}
+}
+
+func TestFastGenByArgsFreezeStringArg(t *testing.T) {
+	errTest := Normalize("Incorrect time value: '%s'", RFCCodeText("Internal:Test"))
+
+	origin := []byte("120120519090607")
+	arg := *(*string)(unsafe.Pointer(&origin))
+	err := errTest.FastGenByArgs(arg)
+
+	copy(origin, "1 1:1:1.0000027")
+	got := err.(*withStack).error.(*Error).GetMsg()
+	want := "Incorrect time value: '120120519090607'"
+	if got != want {
+		t.Fatalf("message changed after source bytes mutated, got %q, want %q", got, want)
 	}
 }

--- a/normalize_test.go
+++ b/normalize_test.go
@@ -7,6 +7,14 @@ import (
 	"unsafe"
 )
 
+type hackedStringArg struct {
+	raw []byte
+}
+
+func (h hackedStringArg) FreezeStr() string {
+	return string(append([]byte(nil), h.raw...))
+}
+
 func errorMatches(t *testing.T, err error, re string) {
 	if err == nil && re != "" {
 		t.Errorf("nil error doesn't match %s", re)
@@ -51,11 +59,26 @@ func TestRedactFormatter(t *testing.T) {
 	}
 }
 
-func TestGenWithStackByArgsFreezeStringArg(t *testing.T) {
+func TestGenWithStackByArgsNoCloneByDefault(t *testing.T) {
 	errTest := Normalize("Incorrect time value: '%s'", RFCCodeText("Internal:Test"))
 
 	origin := []byte("120120519090607")
 	arg := *(*string)(unsafe.Pointer(&origin))
+	err := errTest.GenWithStackByArgs(arg)
+
+	copy(origin, "1 1:1:1.0000027")
+	got := err.(*withStack).error.(*Error).GetMsg()
+	want := "Incorrect time value: '1 1:1:1.0000027'"
+	if got != want {
+		t.Fatalf("message should track source bytes by default, got %q, want %q", got, want)
+	}
+}
+
+func TestGenWithStackByArgsFreezeHackedStringArg(t *testing.T) {
+	errTest := Normalize("Incorrect time value: '%s'", RFCCodeText("Internal:Test"))
+
+	origin := []byte("120120519090607")
+	arg := hackedStringArg{raw: origin}
 	err := errTest.GenWithStackByArgs(arg)
 
 	copy(origin, "1 1:1:1.0000027")
@@ -66,11 +89,11 @@ func TestGenWithStackByArgsFreezeStringArg(t *testing.T) {
 	}
 }
 
-func TestFastGenByArgsFreezeStringArg(t *testing.T) {
+func TestFastGenByArgsFreezeHackedStringArg(t *testing.T) {
 	errTest := Normalize("Incorrect time value: '%s'", RFCCodeText("Internal:Test"))
 
 	origin := []byte("120120519090607")
-	arg := *(*string)(unsafe.Pointer(&origin))
+	arg := hackedStringArg{raw: origin}
 	err := errTest.FastGenByArgs(arg)
 
 	copy(origin, "1 1:1:1.0000027")
@@ -81,11 +104,11 @@ func TestFastGenByArgsFreezeStringArg(t *testing.T) {
 	}
 }
 
-func TestGenWithStackFreezeStringArg(t *testing.T) {
+func TestGenWithStackFreezeHackedStringArg(t *testing.T) {
 	errTest := Normalize("Incorrect time value: '%s'", RFCCodeText("Internal:Test"))
 
 	origin := []byte("120120519090607")
-	arg := *(*string)(unsafe.Pointer(&origin))
+	arg := hackedStringArg{raw: origin}
 	err := errTest.GenWithStack("Incorrect time value: '%s'", arg)
 
 	copy(origin, "1 1:1:1.0000027")
@@ -96,11 +119,11 @@ func TestGenWithStackFreezeStringArg(t *testing.T) {
 	}
 }
 
-func TestFastGenFreezeStringArg(t *testing.T) {
+func TestFastGenFreezeHackedStringArg(t *testing.T) {
 	errTest := Normalize("Incorrect time value: '%s'", RFCCodeText("Internal:Test"))
 
 	origin := []byte("120120519090607")
-	arg := *(*string)(unsafe.Pointer(&origin))
+	arg := hackedStringArg{raw: origin}
 	err := errTest.FastGen("Incorrect time value: '%s'", arg)
 
 	copy(origin, "1 1:1:1.0000027")
@@ -111,11 +134,11 @@ func TestFastGenFreezeStringArg(t *testing.T) {
 	}
 }
 
-func TestGenWithStackByCauseFreezeStringArg(t *testing.T) {
+func TestGenWithStackByCauseFreezeHackedStringArg(t *testing.T) {
 	errTest := Normalize("Incorrect time value: '%s'", RFCCodeText("Internal:Test"))
 
 	origin := []byte("120120519090607")
-	arg := *(*string)(unsafe.Pointer(&origin))
+	arg := hackedStringArg{raw: origin}
 	err := errTest.GenWithStackByCause(arg)
 
 	copy(origin, "1 1:1:1.0000027")
@@ -126,11 +149,11 @@ func TestGenWithStackByCauseFreezeStringArg(t *testing.T) {
 	}
 }
 
-func TestFastGenWithCauseFreezeStringArg(t *testing.T) {
+func TestFastGenWithCauseFreezeHackedStringArg(t *testing.T) {
 	errTest := Normalize("Incorrect time value: '%s'", RFCCodeText("Internal:Test"))
 
 	origin := []byte("120120519090607")
-	arg := *(*string)(unsafe.Pointer(&origin))
+	arg := hackedStringArg{raw: origin}
 	err := errTest.FastGenWithCause(arg)
 
 	copy(origin, "1 1:1:1.0000027")

--- a/normalize_test.go
+++ b/normalize_test.go
@@ -80,3 +80,63 @@ func TestFastGenByArgsFreezeStringArg(t *testing.T) {
 		t.Fatalf("message changed after source bytes mutated, got %q, want %q", got, want)
 	}
 }
+
+func TestGenWithStackFreezeStringArg(t *testing.T) {
+	errTest := Normalize("Incorrect time value: '%s'", RFCCodeText("Internal:Test"))
+
+	origin := []byte("120120519090607")
+	arg := *(*string)(unsafe.Pointer(&origin))
+	err := errTest.GenWithStack("Incorrect time value: '%s'", arg)
+
+	copy(origin, "1 1:1:1.0000027")
+	got := err.(*withStack).error.(*Error).GetMsg()
+	want := "Incorrect time value: '120120519090607'"
+	if got != want {
+		t.Fatalf("message changed after source bytes mutated, got %q, want %q", got, want)
+	}
+}
+
+func TestFastGenFreezeStringArg(t *testing.T) {
+	errTest := Normalize("Incorrect time value: '%s'", RFCCodeText("Internal:Test"))
+
+	origin := []byte("120120519090607")
+	arg := *(*string)(unsafe.Pointer(&origin))
+	err := errTest.FastGen("Incorrect time value: '%s'", arg)
+
+	copy(origin, "1 1:1:1.0000027")
+	got := err.(*withStack).error.(*Error).GetMsg()
+	want := "Incorrect time value: '120120519090607'"
+	if got != want {
+		t.Fatalf("message changed after source bytes mutated, got %q, want %q", got, want)
+	}
+}
+
+func TestGenWithStackByCauseFreezeStringArg(t *testing.T) {
+	errTest := Normalize("Incorrect time value: '%s'", RFCCodeText("Internal:Test"))
+
+	origin := []byte("120120519090607")
+	arg := *(*string)(unsafe.Pointer(&origin))
+	err := errTest.GenWithStackByCause(arg)
+
+	copy(origin, "1 1:1:1.0000027")
+	got := err.(*withStack).error.(*Error).GetMsg()
+	want := "Incorrect time value: '120120519090607'"
+	if got != want {
+		t.Fatalf("message changed after source bytes mutated, got %q, want %q", got, want)
+	}
+}
+
+func TestFastGenWithCauseFreezeStringArg(t *testing.T) {
+	errTest := Normalize("Incorrect time value: '%s'", RFCCodeText("Internal:Test"))
+
+	origin := []byte("120120519090607")
+	arg := *(*string)(unsafe.Pointer(&origin))
+	err := errTest.FastGenWithCause(arg)
+
+	copy(origin, "1 1:1:1.0000027")
+	got := err.(*withStack).error.(*Error).GetMsg()
+	want := "Incorrect time value: '120120519090607'"
+	if got != want {
+		t.Fatalf("message changed after source bytes mutated, got %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
## Summary

This PR introduces **opt-in** argument freezing for normalized errors via a new `HackedStr` interface, instead of freezing all `string` args.

Ref: pingcap/tidb#66834

## Problem

In TiDB, some error args may come from unsafe/ephemeral string sources (for example chunk-backed views). Because `pingcap/errors` formats message args lazily in `GetMsg()/Error()`, those values may change before formatting and produce incorrect text.

At the same time, freezing every plain `string` argument has broad performance cost and changes default behavior.

## Design

Add a dedicated interface for explicit opt-in freezing:

```go
type HackedStr interface {
    FreezeStr() string
}
```

`FreezeStr` is intentionally named differently from generic `Clone` to reduce accidental interface matches from unrelated types.

## Changes

- Add `HackedStr` in `normalize.go`.
- Add `freezeHackedStringArgs(args []interface{})` and apply it to all `err.args` assignment paths:
  - `GenWithStack`
  - `GenWithStackByArgs`
  - `FastGen`
  - `FastGenByArgs`
  - `FastGenWithCause`
  - `GenWithStackByCause`
- Keep normal string behavior unchanged by default (no implicit freezing of plain `string`).
- Update comments/naming to use "freeze" terminology consistently.

## Tests

Added regression coverage for both semantics:

- Plain `string` args are **not** frozen by default (`TestGenWithStackByArgsNoCloneByDefault`).
- `HackedStr` args are frozen correctly across all generation paths:
  - `TestGenWithStackByArgsFreezeHackedStringArg`
  - `TestFastGenByArgsFreezeHackedStringArg`
  - `TestGenWithStackFreezeHackedStringArg`
  - `TestFastGenFreezeHackedStringArg`
  - `TestGenWithStackByCauseFreezeHackedStringArg`
  - `TestFastGenWithCauseFreezeHackedStringArg`

## Benchmark

`no-type-check.txt` is the original version
`check-and-freeze.txt` is this pr

with plain text, about 30% incr due to type checking

```
goos: darwin
goarch: arm64
pkg: github.com/pingcap/errors
cpu: Apple M4
                                                                       │ no-type-check.txt │          check-and-freeze.txt           │
                                                                       │      sec/op       │     sec/op      vs base                 │
ByArgsHackedStrFreeze/FastGenByArgs/type-plain/count-1/strlen-16-10           41.41n ±  1%     51.17n ± 26%    +23.57% (p=0.002 n=6)
ByArgsHackedStrFreeze/FastGenByArgs/type-plain/count-1/strlen-1024-10         42.69n ± 27%     45.47n ±  9%          ~ (p=0.240 n=6)
ByArgsHackedStrFreeze/FastGenByArgs/type-plain/count-4/strlen-16-10           41.49n ± 14%     57.76n ± 41%    +39.21% (p=0.002 n=6)
ByArgsHackedStrFreeze/FastGenByArgs/type-plain/count-4/strlen-1024-10         41.41n ±  6%     49.98n ±  2%    +20.67% (p=0.002 n=6)
ByArgsHackedStrFreeze/FastGenByArgs/type-plain/count-8/strlen-16-10           42.81n ±  8%     57.84n ±  2%    +35.10% (p=0.002 n=6)
ByArgsHackedStrFreeze/FastGenByArgs/type-plain/count-8/strlen-1024-10         43.34n ± 22%     58.31n ±  3%    +34.57% (p=0.002 n=6)
ByArgsHackedStrFreeze/FastGenByArgs/type-hacked/count-1/strlen-16-10          42.00n ± 16%     84.99n ±  1%   +102.34% (p=0.002 n=6)
ByArgsHackedStrFreeze/FastGenByArgs/type-hacked/count-1/strlen-1024-10        42.48n ± 39%    237.70n ± 36%   +459.49% (p=0.002 n=6)
ByArgsHackedStrFreeze/FastGenByArgs/type-hacked/count-4/strlen-16-10          41.94n ± 19%    224.50n ± 21%   +435.29% (p=0.002 n=6)
ByArgsHackedStrFreeze/FastGenByArgs/type-hacked/count-4/strlen-1024-10        41.42n ±  2%    874.65n ± 30%  +2011.41% (p=0.002 n=6)
ByArgsHackedStrFreeze/FastGenByArgs/type-hacked/count-8/strlen-16-10          45.09n ± 37%    366.10n ±  4%   +711.84% (p=0.002 n=6)
ByArgsHackedStrFreeze/FastGenByArgs/type-hacked/count-8/strlen-1024-10        41.57n ±  2%   1449.50n ±  4%  +3386.89% (p=0.002 n=6)
geomean                                                                       42.29n           138.0n         +226.28%

                                                                       │ no-type-check.txt │           check-and-freeze.txt           │
                                                                       │       B/op        │     B/op      vs base                    │
ByArgsHackedStrFreeze/FastGenByArgs/type-plain/count-1/strlen-16-10             152.0 ± 0%     152.0 ± 0%           ~ (p=1.000 n=6) ¹
ByArgsHackedStrFreeze/FastGenByArgs/type-plain/count-1/strlen-1024-10           152.0 ± 0%     152.0 ± 0%           ~ (p=1.000 n=6) ¹
ByArgsHackedStrFreeze/FastGenByArgs/type-plain/count-4/strlen-16-10             152.0 ± 0%     152.0 ± 0%           ~ (p=1.000 n=6) ¹
ByArgsHackedStrFreeze/FastGenByArgs/type-plain/count-4/strlen-1024-10           152.0 ± 0%     152.0 ± 0%           ~ (p=1.000 n=6) ¹
ByArgsHackedStrFreeze/FastGenByArgs/type-plain/count-8/strlen-16-10             152.0 ± 0%     152.0 ± 0%           ~ (p=1.000 n=6) ¹
ByArgsHackedStrFreeze/FastGenByArgs/type-plain/count-8/strlen-1024-10           152.0 ± 0%     152.0 ± 0%           ~ (p=1.000 n=6) ¹
ByArgsHackedStrFreeze/FastGenByArgs/type-hacked/count-1/strlen-16-10            152.0 ± 0%     200.0 ± 0%     +31.58% (p=0.002 n=6)
ByArgsHackedStrFreeze/FastGenByArgs/type-hacked/count-1/strlen-1024-10          152.0 ± 0%    2216.0 ± 0%   +1357.89% (p=0.002 n=6)
ByArgsHackedStrFreeze/FastGenByArgs/type-hacked/count-4/strlen-16-10            152.0 ± 0%     344.0 ± 0%    +126.32% (p=0.002 n=6)
ByArgsHackedStrFreeze/FastGenByArgs/type-hacked/count-4/strlen-1024-10          152.0 ± 0%    8408.0 ± 0%   +5431.58% (p=0.002 n=6)
ByArgsHackedStrFreeze/FastGenByArgs/type-hacked/count-8/strlen-16-10            152.0 ± 0%     536.0 ± 0%    +252.63% (p=0.002 n=6)
ByArgsHackedStrFreeze/FastGenByArgs/type-hacked/count-8/strlen-1024-10          152.0 ± 0%   16664.0 ± 0%  +10863.16% (p=0.002 n=6)
geomean                                                                         152.0          477.7         +214.28%
¹ all samples are equal

                                                                       │ no-type-check.txt │          check-and-freeze.txt          │
                                                                       │     allocs/op     │  allocs/op   vs base                   │
ByArgsHackedStrFreeze/FastGenByArgs/type-plain/count-1/strlen-16-10             2.000 ± 0%    2.000 ± 0%          ~ (p=1.000 n=6) ¹
ByArgsHackedStrFreeze/FastGenByArgs/type-plain/count-1/strlen-1024-10           2.000 ± 0%    2.000 ± 0%          ~ (p=1.000 n=6) ¹
ByArgsHackedStrFreeze/FastGenByArgs/type-plain/count-4/strlen-16-10             2.000 ± 0%    2.000 ± 0%          ~ (p=1.000 n=6) ¹
ByArgsHackedStrFreeze/FastGenByArgs/type-plain/count-4/strlen-1024-10           2.000 ± 0%    2.000 ± 0%          ~ (p=1.000 n=6) ¹
ByArgsHackedStrFreeze/FastGenByArgs/type-plain/count-8/strlen-16-10             2.000 ± 0%    2.000 ± 0%          ~ (p=1.000 n=6) ¹
ByArgsHackedStrFreeze/FastGenByArgs/type-plain/count-8/strlen-1024-10           2.000 ± 0%    2.000 ± 0%          ~ (p=1.000 n=6) ¹
ByArgsHackedStrFreeze/FastGenByArgs/type-hacked/count-1/strlen-16-10            2.000 ± 0%    5.000 ± 0%   +150.00% (p=0.002 n=6)
ByArgsHackedStrFreeze/FastGenByArgs/type-hacked/count-1/strlen-1024-10          2.000 ± 0%    5.000 ± 0%   +150.00% (p=0.002 n=6)
ByArgsHackedStrFreeze/FastGenByArgs/type-hacked/count-4/strlen-16-10            2.000 ± 0%   14.000 ± 0%   +600.00% (p=0.002 n=6)
ByArgsHackedStrFreeze/FastGenByArgs/type-hacked/count-4/strlen-1024-10          2.000 ± 0%   14.000 ± 0%   +600.00% (p=0.002 n=6)
ByArgsHackedStrFreeze/FastGenByArgs/type-hacked/count-8/strlen-16-10            2.000 ± 0%   26.000 ± 0%  +1200.00% (p=0.002 n=6)
ByArgsHackedStrFreeze/FastGenByArgs/type-hacked/count-8/strlen-1024-10          2.000 ± 0%   26.000 ± 0%  +1200.00% (p=0.002 n=6)
geomean                                                                         2.000         4.942        +147.08%
¹ all samples are equal

```

type checking for string and int seems no much difference
```
BenchmarkByArgsHackedStrFreeze
BenchmarkByArgsHackedStrFreeze/FastGenByArgs
BenchmarkByArgsHackedStrFreeze/FastGenByArgs/type-plain/count-1/strlen-16
BenchmarkByArgsHackedStrFreeze/FastGenByArgs/type-plain/count-1/strlen-16-10         	28092688	        41.91 ns/op	     152 B/op	       2 allocs/op
BenchmarkByArgsHackedStrFreeze/FastGenByArgs/type-plain/count-1/strlen-16-10         	28336192	        42.48 ns/op	     152 B/op	       2 allocs/op
BenchmarkByArgsHackedStrFreeze/FastGenByArgs/type-plain/count-1/strlen-16-10         	28242825	        42.06 ns/op	     152 B/op	       2 allocs/op
BenchmarkByArgsHackedStrFreeze/FastGenByArgs/type-plain/count-1/strlen-16-10         	28544752	        42.10 ns/op	     152 B/op	       2 allocs/op
BenchmarkByArgsHackedStrFreeze/FastGenByArgs/type-plain/count-1/strlen-16-10         	28435260	        42.33 ns/op	     152 B/op	       2 allocs/op
BenchmarkByArgsHackedStrFreeze/FastGenByArgs/type-plain/count-1/strlen-16-10         	28382380	        42.17 ns/op	     152 B/op	       2 allocs/op
BenchmarkByArgsHackedStrFreeze/FastGenByArgs/type-plain/count-4/strlen-16
BenchmarkByArgsHackedStrFreeze/FastGenByArgs/type-plain/count-4/strlen-16-10         	25596018	        46.81 ns/op	     152 B/op	       2 allocs/op
BenchmarkByArgsHackedStrFreeze/FastGenByArgs/type-plain/count-4/strlen-16-10         	25366358	        46.99 ns/op	     152 B/op	       2 allocs/op
BenchmarkByArgsHackedStrFreeze/FastGenByArgs/type-plain/count-4/strlen-16-10         	25892061	        46.86 ns/op	     152 B/op	       2 allocs/op
BenchmarkByArgsHackedStrFreeze/FastGenByArgs/type-plain/count-4/strlen-16-10         	25822138	        46.78 ns/op	     152 B/op	       2 allocs/op
BenchmarkByArgsHackedStrFreeze/FastGenByArgs/type-plain/count-4/strlen-16-10         	25696344	        46.87 ns/op	     152 B/op	       2 allocs/op
BenchmarkByArgsHackedStrFreeze/FastGenByArgs/type-plain/count-4/strlen-16-10         	25732068	        46.61 ns/op	     152 B/op	       2 allocs/op
BenchmarkByArgsHackedStrFreeze/FastGenByArgs/type-plain/count-8/strlen-16
BenchmarkByArgsHackedStrFreeze/FastGenByArgs/type-plain/count-8/strlen-16-10         	21197418	        56.62 ns/op	     152 B/op	       2 allocs/op
BenchmarkByArgsHackedStrFreeze/FastGenByArgs/type-plain/count-8/strlen-16-10         	19652182	        56.27 ns/op	     152 B/op	       2 allocs/op
BenchmarkByArgsHackedStrFreeze/FastGenByArgs/type-plain/count-8/strlen-16-10         	21392550	        56.17 ns/op	     152 B/op	       2 allocs/op
BenchmarkByArgsHackedStrFreeze/FastGenByArgs/type-plain/count-8/strlen-16-10         	21109540	        55.84 ns/op	     152 B/op	       2 allocs/op
BenchmarkByArgsHackedStrFreeze/FastGenByArgs/type-plain/count-8/strlen-16-10         	21302341	        56.37 ns/op	     152 B/op	       2 allocs/op
BenchmarkByArgsHackedStrFreeze/FastGenByArgs/type-plain/count-8/strlen-16-10         	21098622	        71.60 ns/op	     152 B/op	       2 allocs/op
BenchmarkByArgsHackedStrFreeze/FastGenByArgs/type-int/count-1/strlen-16
BenchmarkByArgsHackedStrFreeze/FastGenByArgs/type-int/count-1/strlen-16-10           	26332366	        51.64 ns/op	     152 B/op	       2 allocs/op
BenchmarkByArgsHackedStrFreeze/FastGenByArgs/type-int/count-1/strlen-16-10           	27167836	        43.46 ns/op	     152 B/op	       2 allocs/op
BenchmarkByArgsHackedStrFreeze/FastGenByArgs/type-int/count-1/strlen-16-10           	26543216	        44.80 ns/op	     152 B/op	       2 allocs/op
BenchmarkByArgsHackedStrFreeze/FastGenByArgs/type-int/count-1/strlen-16-10           	24279435	        45.59 ns/op	     152 B/op	       2 allocs/op
BenchmarkByArgsHackedStrFreeze/FastGenByArgs/type-int/count-1/strlen-16-10           	27352972	        54.92 ns/op	     152 B/op	       2 allocs/op
BenchmarkByArgsHackedStrFreeze/FastGenByArgs/type-int/count-1/strlen-16-10           	27435835	        43.83 ns/op	     152 B/op	       2 allocs/op
BenchmarkByArgsHackedStrFreeze/FastGenByArgs/type-int/count-4/strlen-16
BenchmarkByArgsHackedStrFreeze/FastGenByArgs/type-int/count-4/strlen-16-10           	24861663	        49.19 ns/op	     152 B/op	       2 allocs/op
BenchmarkByArgsHackedStrFreeze/FastGenByArgs/type-int/count-4/strlen-16-10           	22422832	        47.43 ns/op	     152 B/op	       2 allocs/op
BenchmarkByArgsHackedStrFreeze/FastGenByArgs/type-int/count-4/strlen-16-10           	25585875	        46.94 ns/op	     152 B/op	       2 allocs/op
BenchmarkByArgsHackedStrFreeze/FastGenByArgs/type-int/count-4/strlen-16-10           	25280766	        52.42 ns/op	     152 B/op	       2 allocs/op
BenchmarkByArgsHackedStrFreeze/FastGenByArgs/type-int/count-4/strlen-16-10           	22292022	        47.91 ns/op	     152 B/op	       2 allocs/op
BenchmarkByArgsHackedStrFreeze/FastGenByArgs/type-int/count-4/strlen-16-10           	25230601	        47.62 ns/op	     152 B/op	       2 allocs/op
BenchmarkByArgsHackedStrFreeze/FastGenByArgs/type-int/count-8/strlen-16
BenchmarkByArgsHackedStrFreeze/FastGenByArgs/type-int/count-8/strlen-16-10           	20594538	        57.29 ns/op	     152 B/op	       2 allocs/op
BenchmarkByArgsHackedStrFreeze/FastGenByArgs/type-int/count-8/strlen-16-10           	20420534	        57.21 ns/op	     152 B/op	       2 allocs/op
BenchmarkByArgsHackedStrFreeze/FastGenByArgs/type-int/count-8/strlen-16-10           	21137629	        57.02 ns/op	     152 B/op	       2 allocs/op
BenchmarkByArgsHackedStrFreeze/FastGenByArgs/type-int/count-8/strlen-16-10           	20674476	        57.01 ns/op	     152 B/op	       2 allocs/op
BenchmarkByArgsHackedStrFreeze/FastGenByArgs/type-int/count-8/strlen-16-10           	20842785	        58.12 ns/op	     152 B/op	       2 allocs/op
BenchmarkByArgsHackedStrFreeze/FastGenByArgs/type-int/count-8/strlen-16-10           	20735640	        57.47 ns/op	     152 B/op	       2 allocs/op

```

## Verification

```bash
go test ./...
go test ./... -run '^$' -bench '^BenchmarkByArgsHackedStrFreeze$' -benchmem -count=1
```