### PR TITLE
fix named error verbose stack formatting

### DIFF
--- a/normalize.go
+++ b/normalize.go
@@ -92,6 +92,7 @@ type Error struct {
 }
 
 var _ messenger = (*Error)(nil)
+var _ fmt.Formatter = (*Error)(nil)
 
 // Code returns the numeric code of this error.
 // ID() will return textual error if there it is,
@@ -142,6 +143,26 @@ func (e *Error) Error() string {
 		return fmt.Sprintf("[%s]%s: %s", e.RFCCode(), e.GetMsg(), e.cause.Error())
 	}
 	return fmt.Sprintf("[%s]%s", e.RFCCode(), e.GetMsg())
+}
+
+func (e *Error) Format(s fmt.State, verb rune) {
+	switch verb {
+	case 'v':
+		if s.Flag('+') {
+			if e != nil && e.cause != nil {
+				fmt.Fprintf(s, "%+v\n", e.cause)
+				fmt.Fprintf(s, "[%s]%s", e.RFCCode(), e.GetMsg())
+				return
+			}
+			fmt.Fprint(s, e.Error())
+			return
+		}
+		fallthrough
+	case 's':
+		fmt.Fprint(s, e.Error())
+	case 'q':
+		fmt.Fprintf(s, "%q", e.Error())
+	}
 }
 
 func (e *Error) GetMsg() string {

--- a/normalize_test.go
+++ b/normalize_test.go
@@ -1,8 +1,10 @@
 package errors
 
 import (
+	stderrors "errors"
 	"fmt"
 	"regexp"
+	"strings"
 	"testing"
 	"unsafe"
 )
@@ -40,6 +42,39 @@ func TestCauseInErrorMessage(t *testing.T) {
 
 	notWrapped := errTest.GenWithStack("everything is alright")
 	errorMatches(t, notWrapped, `^\[Internal:Test\]everything is alright$`)
+}
+
+func TestWrappedNamedErrorGenWithStackByArgsFormatsCauseStack(t *testing.T) {
+	errTest := Normalize("named error: %s", RFCCodeText("Internal:Test"))
+
+	err := errTest.Wrap(New("cause error")).GenWithStackByArgs("wrapped")
+
+	if _, ok := err.(fmt.Formatter); !ok {
+		t.Fatalf("zap requires fmt.Formatter to emit errorVerbose for stackful errors, got %T", err)
+	}
+
+	formatted := fmt.Sprintf("%+v", err)
+	if !strings.Contains(formatted, "github.com/pingcap/errors.TestWrappedNamedErrorGenWithStackByArgsFormatsCauseStack") {
+		t.Fatalf("formatted error does not contain the wrapped cause stack:\n%s", formatted)
+	}
+	if !strings.Contains(formatted, "[Internal:Test]named error: wrapped") {
+		t.Fatalf("formatted error does not contain named error context:\n%s", formatted)
+	}
+}
+
+func TestWrappedNamedErrorFormatsStacklessCause(t *testing.T) {
+	errTest := Normalize("named error: %s", RFCCodeText("Internal:Test"))
+
+	err := errTest.Wrap(stderrors.New("plain cause")).GenWithStackByArgs("wrapped")
+
+	formatted := fmt.Sprintf("%+v", err)
+	wantPrefix := "plain cause\n[Internal:Test]named error: wrapped\n"
+	if !strings.HasPrefix(formatted, wantPrefix) {
+		t.Fatalf("unexpected formatted error prefix:\ngot:  %q\nwant prefix: %q", formatted, wantPrefix)
+	}
+	if !strings.Contains(formatted, "github.com/pingcap/errors.TestWrappedNamedErrorFormatsStacklessCause") {
+		t.Fatalf("formatted error does not contain the generated stack:\n%s", formatted)
+	}
 }
 
 func TestRedactFormatter(t *testing.T) {


### PR DESCRIPTION
## What changed

- Make `*Error` implement `fmt.Formatter` so zap can emit `errorVerbose` for named errors.
- Preserve existing stack deduplication by formatting an already-stacked cause with `%+v` instead of forcing another stack.
- Add a regression test for `Error.Wrap(errors.New()).GenWithStackByArgs()` verifying formatter exposure and stack output.

## Why

`GenWithStackByArgs` delegates to `AddStack`. If the named error wraps a cause that already has a stack, `AddStack` returns the bare `*Error`. Because `*Error` did not implement `fmt.Formatter`, zap only logged the plain error string and skipped the verbose stack field.

## Validation

- `go test -count=1 ./...`